### PR TITLE
[Enhance] Pixel 컴포넌트 리렌더링 개선

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import "./App.css";
 
-import { useReducer, useState } from "react";
+import { useMemo, useReducer, useState } from "react";
 
 import PixelContainer from "./components/PixelContainer";
 
@@ -28,7 +28,7 @@ import ColorPallete from "./components/ColorPallete";
 
 import gridReducer from "./reducers/gridReducer";
 
-import { GridSizeActionKind, UPDATE_GRID } from "./constants/actionTypes";
+import { GridSizeActionKind } from "./constants/actionTypes";
 
 function App() {
   const [toolOptions, setToolOptions] = useState(INITIAL_TOOL_OPTIONS);
@@ -60,6 +60,10 @@ function App() {
     });
   };
 
+  const memoizedGrid = useMemo(() => {
+    return state.grid;
+  }, [state.grid]);
+
   return (
     <>
       <div className="min-h-screen bg-black">
@@ -79,13 +83,8 @@ function App() {
                     <PixelContainer
                       columns={state.columns}
                       rows={state.rows}
-                      grid={state.grid}
-                      onUpdateGrid={(newGrid) => {
-                        dispatch({
-                          type: UPDATE_GRID,
-                          payload: newGrid,
-                        });
-                      }}
+                      grid={memoizedGrid}
+                      dispatch={dispatch}
                       toolOptions={toolOptions}
                       selectedTool={selectedTool}
                     />

--- a/frontend/src/components/Pixel.tsx
+++ b/frontend/src/components/Pixel.tsx
@@ -7,70 +7,67 @@ type PixelProps = {
   color: string;
   rowIdx: number;
   columns: number;
-  toolActive: boolean;
   onPointerDown: (id: number) => void;
   onPointerEnter: (id: number) => void;
   onPointerLeave: (id: number) => void;
-  onToolActive: (down: boolean) => void;
+  onPointerMove: (id: number) => void;
+  onPointerUp: () => void;
 };
 
-const Pixel = ({
-  id,
-  color,
-  rowIdx,
-  columns,
-  toolActive,
-  onPointerDown,
-  onPointerEnter,
-  onPointerLeave,
-  onToolActive,
-}: PixelProps) => {
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLDivElement;
+const Pixel = React.memo(
+  ({
+    id,
+    color,
+    rowIdx,
+    columns,
+    onPointerDown,
+    onPointerEnter,
+    onPointerLeave,
+    onPointerMove,
+    onPointerUp,
+  }: PixelProps) => {
 
-    if (target?.hasPointerCapture(e.pointerId)) {
-      target?.releasePointerCapture(e.pointerId);
-    }
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLDivElement;
 
-    onToolActive(true);
-    onPointerDown(id);
-  };
-
-  const handlePointerMove = () => {
-    if (toolActive) {
+      if (target?.hasPointerCapture(e.pointerId)) {
+        target?.releasePointerCapture(e.pointerId);
+      }
       onPointerDown(id);
-    }
-  };
+    };
 
-  const handlePointerEnter = () => {
-    onPointerEnter(id);
-  };
+    const handlePointerMove = () => {
+      onPointerMove(id);
+    };
 
-  const handlePointerLeave = () => {
-    onPointerLeave(id);
-  };
+    const handlePointerEnter = () => {
+      onPointerEnter(id);
+    };
 
-  const gridBackgroundColor: Indexable<string> = {
-    0: "bg-[#d9d9d9]",
-    1: "bg-white",
-  };
+    const handlePointerLeave = () => {
+      onPointerLeave(id);
+    };
 
-  const gridBgIdx = getGridBackgroundIndex(id, columns, rowIdx);
-  return (
-    <div
-      aria-label="pixel"
-      data-grid-bg-idx={gridBgIdx}
-      className={`pixel w-[calc(100%/${columns})] pb-[calc(100%/${columns})] border-neutral-500 ${gridBackgroundColor[gridBgIdx]}`}
-      style={{ backgroundColor: color }}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerEnter={handlePointerEnter}
-      onPointerLeave={handlePointerLeave}
-      onPointerUp={() => {
-        onToolActive(false);
-      }}
-    ></div>
-  );
-};
+    const gridBackgroundColor: Indexable<string> = {
+      0: "bg-[#d9d9d9]",
+      1: "bg-white",
+    };
 
+    const gridBgIdx = getGridBackgroundIndex(id, columns, rowIdx);
+    return (
+      <div
+        aria-label="pixel"
+        data-color={color}
+        data-grid-bg-idx={gridBgIdx}
+        className={`pixel w-[calc(100%/${columns})] pb-[calc(100%/${columns})] border-neutral-500 ${gridBackgroundColor[gridBgIdx]}`}
+        style={{ backgroundColor: color }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        onPointerUp={onPointerUp}
+      ></div>
+    );
+  }
+);
 export default Pixel;

--- a/frontend/src/components/PixelContainer.test.tsx
+++ b/frontend/src/components/PixelContainer.test.tsx
@@ -8,6 +8,7 @@ import PixelContainer from "./PixelContainer";
 import { Tool } from "../types/Tool";
 
 import { INITIAL_TOOL_OPTIONS } from "../constants";
+import { ToolActionKind } from "../constants/actionTypes";
 
 describe("PixelContainer", () => {
   beforeEach(() => {
@@ -22,21 +23,30 @@ describe("PixelContainer", () => {
     rows = 25,
     grid = Array(25).fill(""),
     toolOptions = INITIAL_TOOL_OPTIONS,
-    onUpdateGrid = (newGrid: string[]) => {
-      /* */
-    },
     selectedTool = "pen" as Tool,
   }) => {
+    const dispatch = vi.fn();
     render(
       <PixelContainer
         columns={columns}
         rows={rows}
         grid={grid}
         toolOptions={toolOptions}
-        onUpdateGrid={onUpdateGrid}
+        dispatch={dispatch}
         selectedTool={selectedTool}
       />
     );
+    return { dispatch };
+  };
+
+  const getToolOptionsWithPenSize = (size: number) => {
+    return {
+      ...INITIAL_TOOL_OPTIONS,
+      pen: {
+        color: "rgb(54, 255, 121)",
+        size,
+      },
+    };
   };
 
   it("should render a grid of pixels", () => {
@@ -49,134 +59,37 @@ describe("PixelContainer", () => {
   });
 
   describe("Drawing with a pen", () => {
-    let GRID = Array(25).fill("");
 
-    const onUpdateGrid = (newGrid: string[]) => {
-      GRID = newGrid;
-    };
 
-    const getToolOptionsWithPenSize = (size: number) => {
-      return {
-        ...INITIAL_TOOL_OPTIONS,
-        pen: {
-          color: "rgb(54, 255, 121)",
-          size,
+    it("should call dispatch with toolOptions and id", () => {
+      const id = 0;
+      const toolOptions = getToolOptionsWithPenSize(1);
+      const { dispatch } = renderPixels({
+        toolOptions,
+      });
+
+      const pixels = screen.getAllByLabelText("pixel");
+
+      const pixel = pixels[id];
+
+      fireEvent.pointerDown(pixel);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: ToolActionKind.PENCIL,
+        payload: {
+          pen: {
+            color: toolOptions.pen.color,
+            size: toolOptions.pen.size,
+          },
+          id,
         },
-      };
-    };
-
-    describe("When the pen size is 1", () => {
-      const size = 1;
-      const toolOptions = getToolOptionsWithPenSize(size);
-
-      it("should update the color of 1 pixel", () => {
-        renderPixels({
-          toolOptions,
-          onUpdateGrid,
-        });
-
-        const pixels = screen.getAllByLabelText("pixel");
-
-        const pixel = pixels[0];
-
-        fireEvent.pointerDown(pixel);
-
-        expect(GRID[0]).toBe(toolOptions.pen.color);
-      });
-
-      describe("When the pen size is 2", () => {
-        const size = 2;
-        const toolOptions = getToolOptionsWithPenSize(size);
-
-        it("should update the color of 4 pixel", () => {
-          renderPixels({
-            toolOptions,
-            onUpdateGrid,
-          });
-
-          const pixels = screen.getAllByLabelText("pixel");
-
-          const pixel = pixels[0];
-
-          fireEvent.pointerDown(pixel);
-
-          expect(
-            GRID.filter((pixel) => pixel === toolOptions.pen.color).length
-          ).toBe(size ** 2);
-        });
-      });
-
-      describe("When the pen size is 3", () => {
-        const size = 3;
-        const toolOptions = getToolOptionsWithPenSize(size);
-
-        it("should update the color of 9 pixel", () => {
-          renderPixels({
-            toolOptions,
-            onUpdateGrid,
-          });
-
-          const pixels = screen.getAllByLabelText("pixel");
-
-          const pixel = pixels[0];
-
-          fireEvent.pointerDown(pixel);
-
-          expect(
-            GRID.filter((pixel) => pixel === toolOptions.pen.color).length
-          ).toBe(size ** 2);
-        });
-      });
-
-      describe("When the pen size is 4", () => {
-        const size = 4;
-        const toolOptions = getToolOptionsWithPenSize(size);
-
-        it("should update the color of 16 pixel", () => {
-          renderPixels({
-            toolOptions,
-            onUpdateGrid,
-          });
-
-          const pixels = screen.getAllByLabelText("pixel");
-
-          const pixel = pixels[0];
-
-          fireEvent.pointerDown(pixel);
-
-          expect(
-            GRID.filter((pixel) => pixel === toolOptions.pen.color).length
-          ).toBe(size ** 2);
-        });
-      });
-
-      describe("When the pen size is 5", () => {
-        const size = 5;
-        const toolOptions = getToolOptionsWithPenSize(size);
-
-        it("should update the color of 25 pixel", () => {
-          renderPixels({
-            toolOptions,
-            onUpdateGrid,
-          });
-
-          const pixels = screen.getAllByLabelText("pixel");
-
-          const pixel = pixels[0];
-
-          fireEvent.pointerDown(pixel);
-
-          expect(
-            GRID.filter((pixel) => pixel === toolOptions.pen.color).length
-          ).toBe(size ** 2);
-        });
       });
     });
   });
 
   describe("Paint with a bucket", () => {
     const INIT_COLOR = "rgb(116, 185, 255)";
-    let GRID = [
+    const GRID = [
       INIT_COLOR,
       INIT_COLOR,
       INIT_COLOR,
@@ -204,45 +117,33 @@ describe("PixelContainer", () => {
       INIT_COLOR,
     ];
 
-    const onUpdateGrid = (newGrid: string[]) => {
-      GRID = newGrid;
-    };
-
-    const getToolOptionsWithPenSize = (size: number) => {
-      return {
-        ...INITIAL_TOOL_OPTIONS,
-        pen: {
-          color: "rgb(54, 255, 121)",
-          size,
-        },
-      };
-    };
-
     const toolOptions = getToolOptionsWithPenSize(1);
 
-    it("should update the color INIT_COLOR(rgb(116, 185, 255)) should be changed to pen.color(rgb(54, 255, 121))", () => {
-      renderPixels({
+    it("should call dispatch with toolOptions and id", () => {
+      const id = 0
+      const {dispatch} = renderPixels({
         columns: 5,
         rows: 5,
         grid: GRID,
         toolOptions,
-        onUpdateGrid,
         selectedTool: "bucket",
       });
 
       const pixels = screen.getAllByLabelText("pixel");
 
-      const pixel = pixels[0];
-
-      const paintedCount = GRID.filter((color) => color === INIT_COLOR).length;
+      const pixel = pixels[id];
 
       fireEvent.pointerDown(pixel);
 
-      const updatedCount = GRID.filter(
-        (color) => color === toolOptions.pen.color
-      ).length;
-
-      expect(paintedCount).toEqual(updatedCount);
-    });
+      expect(dispatch).toHaveBeenCalledWith({
+        type: ToolActionKind.BUCKET,
+        payload: {
+          pen: {
+            color: toolOptions.pen.color,
+          },
+          id,
+        },
+      });
+    })
   });
 });

--- a/frontend/src/components/PixelContainer.tsx
+++ b/frontend/src/components/PixelContainer.tsx
@@ -1,16 +1,14 @@
-import React, { useState } from "react";
+import React, { Dispatch, useCallback, useState } from "react";
 
 import Pixel from "./Pixel";
 
 import useOutsidePointerUp from "../hooks/useOutsidePointerUp";
-import {
-  getGridBackgroundHoverColor,
-  getBucketFillGridAndIndexes,
-  getTargetIndexes,
-} from "../utils/grid";
+import { getGridBackgroundHoverColor, getTargetIndexes } from "../utils/grid";
 import { getHoverColor } from "../utils/color";
 
 import type { ToolOption, Tool } from "../types/Tool";
+import { ToolActionKind } from "../constants/actionTypes";
+import { Actions } from "../reducers/gridReducer";
 
 type PixelContainerProps = {
   columns: number;
@@ -18,7 +16,7 @@ type PixelContainerProps = {
   grid: string[];
   toolOptions: ToolOption;
   selectedTool: Tool;
-  onUpdateGrid: (newGrid: string[]) => void;
+  dispatch: Dispatch<Actions>;
 };
 
 const PixelContainer = ({
@@ -27,117 +25,155 @@ const PixelContainer = ({
   grid,
   toolOptions,
   selectedTool,
-  onUpdateGrid,
+  dispatch,
 }: PixelContainerProps) => {
   const ref = useOutsidePointerUp(() => setToolActive(false));
+  const [moveIndex, setMoveIndex] = useState<number | null>(null);
 
-  const [toolActive, setToolActive] = useState<boolean>(false);
+  const [toolActive, setToolActive] = useState(false);
 
-  const handlePointerDown = (id: number) => {
-    if (selectedTool === "pen") {
-      const color = toolOptions.pen.color;
-      const size = toolOptions.pen.size;
-      const newGrid = grid.slice();
-      const targetIndexes = getTargetIndexes(id, size, columns, rows);
-
-      targetIndexes.forEach((idx) => {
-        newGrid[idx] = color;
-      });
-
-      onUpdateGrid(newGrid);
-    } else if (selectedTool === "eraser") {
-      const size = toolOptions.eraser.size;
-      const newGrid = grid.slice();
-      const targetIndexes = getTargetIndexes(id, size, columns, rows);
-
-      targetIndexes.forEach((idx) => {
-        newGrid[idx] = "";
-      });
-
-      onUpdateGrid(newGrid);
-    } else if (selectedTool === "bucket") {
-      const originColor = grid[id];
-      const newColor = toolOptions.pen.color;
-
-      const { grid: newGrid } = getBucketFillGridAndIndexes(
-        grid.slice(),
-        id,
-        originColor,
-        newColor,
-        columns,
-        rows
-      );
-
-      onUpdateGrid(newGrid);
+  const handleDrag = () => {
+    if (!toolActive) {
+      return;
     }
+
+    if (!moveIndex) {
+      return;
+    }
+    handlePointerDown(moveIndex);
   };
 
-  const handlePointerEnter = (id: number) => {
-    if (ref.current) {
-      if (selectedTool === "pen" || selectedTool === "eraser") {
-        const indexes = getTargetIndexes(
-          id,
-          toolOptions[selectedTool].size,
-          columns,
-          rows
-        );
-        const pixels = ref.current.querySelectorAll<HTMLDivElement>(".pixel");
-        indexes.forEach((index) => {
-          const painted = grid[index];
+  const handlePointerMove = useCallback((id: number) => {
+    setMoveIndex(id);
+  }, []);
 
-          let hoverColor = "";
-          if (painted) {
-            hoverColor = getHoverColor(painted);
-          } else {
-            const gridBgIdx = pixels[index].dataset.gridBgIdx;
-            hoverColor = getGridBackgroundHoverColor(gridBgIdx as string);
-          }
-          pixels[index].style.backgroundColor = hoverColor;
-        });
+  const handlePointerEnter = useCallback(
+    (id: number) => {
+      if (ref.current) {
+        if (selectedTool === "pen" || selectedTool === "eraser") {
+          const indexes = getTargetIndexes(
+            id,
+            toolOptions[selectedTool].size,
+            columns,
+            rows
+          );
+          const pixels = ref.current.querySelectorAll<HTMLDivElement>(".pixel");
+          indexes.forEach((index) => {
+            const painted = pixels[index].dataset.color;
+
+            let hoverColor = "";
+            if (painted) {
+              hoverColor = getHoverColor(painted);
+            } else {
+              const gridBgIdx = pixels[index].dataset.gridBgIdx;
+              hoverColor = getGridBackgroundHoverColor(gridBgIdx as string);
+            }
+            pixels[index].style.backgroundColor = hoverColor;
+          });
+        }
       }
-    }
-  };
+    },
+    [columns, rows, ref, selectedTool, toolOptions]
+  );
 
-  const handlePointerLeave = (id: number) => {
-    if (ref.current) {
-      if (selectedTool === "pen" || selectedTool === "eraser") {
-        const indexes = getTargetIndexes(
-          id,
-          toolOptions[selectedTool].size,
-          columns,
-          rows
-        );
-        const pixels = ref.current.querySelectorAll<HTMLDivElement>(".pixel");
-        indexes.forEach((index) => {
-          pixels[index].style.backgroundColor = grid[index];
-        });
+  const handlePointerLeave = useCallback(
+    (id: number) => {
+      if (ref.current) {
+        if (selectedTool === "pen" || selectedTool === "eraser") {
+          const indexes = getTargetIndexes(
+            id,
+            toolOptions[selectedTool].size,
+            columns,
+            rows
+          );
+          const pixels = ref.current.querySelectorAll<HTMLDivElement>(".pixel");
+          indexes.forEach((index) => {
+            const paintedColor = pixels[index].dataset.color;
+            pixels[index].style.backgroundColor = paintedColor ?? "";
+          });
+        }
       }
-    }
-  };
+    },
+    [columns, rows, ref, selectedTool, toolOptions]
+  );
 
-  const colPixels = Array.from({ length: columns });
-  const rowPixels = Array.from({ length: rows });
+  const handlePointerDown = useCallback(
+    (id: number) => {
+      if (selectedTool === "pen") {
+        dispatch({
+          type: ToolActionKind.PENCIL,
+          payload: {
+            pen: {
+              color: toolOptions.pen.color,
+              size: toolOptions.pen.size,
+            },
+            id,
+          },
+        });
+      } else if (selectedTool === "eraser") {
+        dispatch({
+          type: ToolActionKind.ERASER,
+          payload: {
+            eraser: {
+              size: toolOptions.eraser.size,
+            },
+            id,
+          },
+        });
+      } else if (selectedTool === "bucket") {
+        dispatch({
+          type: ToolActionKind.BUCKET,
+          payload: {
+            pen: {
+              color: toolOptions.pen.color,
+            },
+            id,
+          },
+        });
+      } else if (selectedTool === "move") {
+        dispatch({
+          type: ToolActionKind.MOVE,
+          payload: {id}
+        }); 
+      }
+
+      setToolActive(true);
+    },
+    [dispatch, selectedTool, toolOptions]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setToolActive(false);
+  }, []);
+
+  const colPixels = React.useMemo(
+    () => Array.from({ length: columns }),
+    [columns]
+  );
+  const rowPixels = React.useMemo(() => Array.from({ length: rows }), [rows]);
 
   return (
     <div
       ref={ref}
       className="flex h-full w-full cursor-cell flex-wrap items-start shadow-2xl"
+      onPointerMove={handleDrag}
     >
       {rowPixels.map((row, rowIdx) => {
         return colPixels.map((col, colIdx) => {
           const id = rowIdx * colPixels.length + colIdx;
+          const color = grid[id];
           return (
             <Pixel
               key={id}
               id={id}
               rowIdx={rowIdx}
               columns={columns}
-              color={grid[id]}
-              toolActive={toolActive}
-              onPointerDown={handlePointerDown}
+              color={color}
               onPointerEnter={handlePointerEnter}
               onPointerLeave={handlePointerLeave}
-              onToolActive={setToolActive}
+              onPointerMove={handlePointerMove}
+              onPointerDown={handlePointerDown}
+              onPointerUp={handlePointerUp}
             />
           );
         });

--- a/frontend/src/constants/actionTypes.ts
+++ b/frontend/src/constants/actionTypes.ts
@@ -1,4 +1,9 @@
-const UPDATE_GRID = "UPDATE_GRID";
+enum ToolActionKind {
+  PENCIL = "PENCIL",
+  ERASER = "ERASER",
+  BUCKET = "BUCKET",
+  MOVE = "MOVE"
+}
 
 enum GridSizeActionKind {
   INCREASE_COLUMN = "INCREASE_COLUMN",
@@ -7,4 +12,4 @@ enum GridSizeActionKind {
   DECREASE_ROW = "DECREASE_ROW",
 }
 
-export { GridSizeActionKind, UPDATE_GRID };
+export { GridSizeActionKind, ToolActionKind };

--- a/frontend/src/types/NestedPartial.ts
+++ b/frontend/src/types/NestedPartial.ts
@@ -1,0 +1,5 @@
+type NestedPartial<T> = {
+  [K in keyof T]?: T[K] extends Array<infer R> ? Array<NestedPartial<R>> : NestedPartial<T[K]>
+};
+
+export type {NestedPartial}

--- a/frontend/tests/utils/getBucketFillGridAndIndexes.test.ts
+++ b/frontend/tests/utils/getBucketFillGridAndIndexes.test.ts
@@ -56,7 +56,6 @@ describe("getBucketFillGridAndIndexes", () => {
         rows
       );
 
-      console.log(newGrid, indexes);
       expect(newGrid).toEqual([
         newColor,
         newColor,


### PR DESCRIPTION
## Description


### ​React.memo로 Pixel 컴포넌트 감싸기
<img width="1278" alt="pixel_rerender" src="https://github.com/LemonScone/pixel-art/assets/6129764/cda0385f-24e2-46ed-8e61-971645820eab">

위 이미지는 하나의 `Pixel` 컴포넌트를 `pen` tool을 이용해 선택했을 때 렌더링입니다. 빨간색으로 표시한 부분이 `Pixel` 컴포넌트 모두가 리렌더링되는 부분입니다. 

tool을 사용한 `Pixel` 컴포넌트(색이 칠해지거나 지워지거나 bucket을 사용하거나)가 아님에도 불구하고 리렌더링되서 앱이 느려졌습니다.  
그래서 `props`이 변경되지 않은 경우에 리렌더링되지 않도록 `React.memo`를 사용했습니다.

```ts
const Pixel = React.memo(
  ({
    id,
    color,
    rowIdx,
    columns,
    onPointerDown,
    onPointerEnter,
    onPointerLeave,
    onPointerMove,
    onPointerUp,
  }: PixelProps) => {
// ...
```


### useMemo, useCallback 활용
<img width="459" alt="why-rerender" src="https://github.com/LemonScone/pixel-art/assets/6129764/b9021d0e-ddc9-4dd2-a225-dcd84c70f4b0">

`React.memo`를 사용해봤지만 개선되지 않았습니다.
생각해보니 전달받은 `props` 중 함수는 원시값이 아니기 때문에 항상 새로운 값이 됩니다. 
위 이미지처럼 리렌더링된 이유가 함수 때문이었습니다.  그래서 함수들에 `useCallback`을 사용했습니다.

다음에 나타난 문제는 tool을 사용했을 때 화면에 그려지는 `grid` state가 변경되기 때문에 이를 함수 내에서 사용하게 되면 `useCallback`도 소용이 없다는 것이었습니다.
```ts
  const handlePointerDown = (id: number) => {
    if (selectedTool === "pen") {
      const color = toolOptions.pen.color;
      const size = toolOptions.pen.size;
      const newGrid = grid.slice(); // `grid` state 수정을 위해 `grid` state를 사용한다. 
      const targetIndexes = getTargetIndexes(id, size, columns, rows);

      targetIndexes.forEach((idx) => {
        newGrid[idx] = color;
      });

      onUpdateGrid(newGrid);
    } 
  // 다른 도구도 마찬가지 
  };
```
그래서 `grid` state를 함수 내에서 사용하지 않도록 `useReducer` 내부에 `grid`, `columns` `rows`가 모두 있으니 action을 보내면 되겠다는 결론을 내렸습니다.

### useReducer로 상태 업데이트하기

`useReducer`에서 사용하는 `ToolAction`을 추가했습니다. 
```ts
enum ToolActionKind {
  PENCIL = "PENCIL",
  ERASER = "ERASER",
  BUCKET = "BUCKET",
  MOVE = "MOVE"
}

type ToolAction = {
  type: ToolActionKind;
  payload: NestedPartial<ToolOption> & { id: number };
};
```

컴포넌트에서는 action만 `dispatch` 합니다.
```ts
const handlePointerDown = useCallback(
    (id: number) => {
      if (selectedTool === "pen") {
        dispatch({
          type: ToolActionKind.PENCIL,
          payload: {
            pen: {
              color: toolOptions.pen.color,
              size: toolOptions.pen.size,
            },
            id,
          },
        });
      }
  // ...
}
```

상태 업데이트는 `reducer`가 처리합니다.

```ts
const gridReducer = (state: GridState, action: Actions) => {
  switch (action.type) {

    case ToolActionKind.PENCIL: {
      const newGrid = state.grid.slice();

      if (action.payload && action.payload.pen) {
        const { pen } = action.payload;
        const color = pen.color as string;
        const size = pen.size as number;

        const targetIndexes = getTargetIndexes(
          action.payload.id,
          size,
          state.columns,
          state.rows
        );

        targetIndexes.forEach((idx) => {
          newGrid[idx] = color;
        });
      }
      return {
        ...state,
        grid: newGrid,
      };
    }
```
### 테스트 코드에 대하여

저희가 그동안 열심히 테스트 코드를 작성했지만, `useReducer`로 방식을 변경했으니 테스트는 당연히 깨졌습니다.
아쉽지만 수정이 필요했는데 어떻게 해야 테스트가  잘 되는 것인지 고민이었습니다.

저의 생각은 '`reducer`가 예상대로 잘 작동되고, `props`에 의해 제대로 렌더링 된다면 (`grid` state에 해당하는 색상값이 `Pixel`에 렌더링됩니다.) tool을 사용했을 때 `dispatch`만 제대로된 값을 담아 전달되는지만 확인하면 되겠다'입니다. `dispatch`가 알아서 `grid` state를 업데이트 해주기 때문입니다.

그래서 다음과 같이 `toHaveBeenCalledWith` matcher로 확인했습니다.
```ts
expect(dispatch).toHaveBeenCalledWith({
        type: ToolActionKind.BUCKET,
        payload: {
          pen: {
            color: toolOptions.pen.color,
          },
          id,
        },
      });
```

### 결과
<img width="1248" alt="개선" src="https://github.com/LemonScone/pixel-art/assets/6129764/c091365d-7ad5-4a25-8cf6-c57fee44c82d">
처음 이미지와 다르게 `Pixel` 컴포넌트들이 모두 리렌더링되지 않는 것을 확인할 수 있었습니다. 

## Related Issues

​
resolve #49
​

## Checklist

​
Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
​

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
