### PR TITLE
[Deploy] github actions workflows target 옵션 수정

### DIFF
--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -26,8 +26,6 @@ jobs:
         run: npm run build
       - name: Package Application
         run: tar -czvf build.tar.gz dist
-      - name: debugging
-        run: ls -al .
       - name: copy build files to EC2
         uses: appleboy/scp-action@master
         with:
@@ -35,7 +33,7 @@ jobs:
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
           source: build.tar.gz
-          target: "/home/ubuntu/pixel-art/frontend/"
+          target: ./
       - name: execute shell script
         uses: appleboy/ssh-action@master
         with:

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1,6 +1,6 @@
 const Gallery = () => {
   return (
-    <div className="flex items-center justify-center text-3xl text-rose-500">
+    <div className="flex items-center justify-center text-3xl text-primary-color">
       Gallery
     </div>
   );


### PR DESCRIPTION
현재 working-directory가 frontend로 되어있기 때문에
`target` 옵션을 이동할 필요가 없습니다.