### PR TITLE
[Deploy] github actions workflows target secret 설정

### DIFF
--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -32,8 +32,8 @@ jobs:
           host: ${{ secrets.REMOTE_IP }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          source: build.tar.gz
-          target: ./
+          source: frontend/build.tar.gz
+          target: ${{ secrets.REMOTE_TARGET }}
       - name: execute shell script
         uses: appleboy/ssh-action@master
         with:

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1,6 +1,6 @@
 const Gallery = () => {
   return (
-    <div className="flex items-center justify-center text-3xl text-primary-color">
+    <div className="flex items-center justify-center text-3xl text-cyan-700	">
       Gallery
     </div>
   );


### PR DESCRIPTION
`working-directory`가 `defaults.run`에 설정되어 있으므로
`appleboy/scp-action`에 적용되지 않았습니다.
따라서 경로를 수정합니다.
