### PR TITLE
[Enhance] resizeGrid 코드 최적화

### DIFF
--- a/frontend/src/components/Pixel.tsx
+++ b/frontend/src/components/Pixel.tsx
@@ -9,12 +9,12 @@ type PixelProps = {
   columns: number;
 };
 
-const Pixel = React.memo(({ id, color, rowIdx, columns }: PixelProps) => {
-  const gridBackgroundColor: Indexable<string> = {
-    0: "bg-[#d9d9d9]",
-    1: "bg-white",
-  };
+const gridBackgroundColor: Indexable<string> = {
+  0: "bg-[#d9d9d9]",
+  1: "bg-white",
+};
 
+const Pixel = React.memo(({ id, color, rowIdx, columns }: PixelProps) => {
   const gridBgIdx = getGridBackgroundIndex(id, columns, rowIdx);
   return (
     <div

--- a/frontend/src/utils/grid.ts
+++ b/frontend/src/utils/grid.ts
@@ -7,27 +7,32 @@ export const resizeGrid = (
   newRows: number,
   newColumns: number
 ) => {
-  //TODO - 배열 계산 최적화
-  // console.time("resizeGrid");
   let newGrid = grid;
-  const originCells = originRows * originColumns;
 
   if (originColumns !== newColumns) {
     // resize by columns
     const diff = Math.abs(newColumns - originColumns);
     const increment = newColumns - originColumns > 0;
     if (increment) {
-      for (let i = originCells; i > 0; i -= originColumns) {
-        const pixels = Array(diff).fill("");
-        newGrid = [...newGrid.slice(0, i), ...pixels, ...newGrid.slice(i)];
-      }
+      newGrid = Array(grid.length + diff * originRows).fill("");
     } else {
-      for (let i = originCells - 1; i > 0; i -= originColumns) {
-        for (let j = 0; j < diff; j++) {
-          newGrid = [...newGrid.slice(0, i - j), ...newGrid.slice(i + 1 - j)];
-        }
-      }
+      newGrid = grid.slice(0, grid.length - diff * originRows);
     }
+
+    newGrid = newGrid.map((_, index) => {
+      const col = index % newColumns;
+      const row = Math.floor(index / newColumns);
+      const originIndex = col + row * originColumns;
+
+      if (
+        col < (increment ? originColumns : newColumns) &&
+        originIndex < grid.length
+      ) {
+        return grid[originIndex];
+      } else {
+        return "";
+      }
+    });
   }
 
   if (originRows !== newRows) {
@@ -35,20 +40,12 @@ export const resizeGrid = (
     const diff = Math.abs(newRows - originRows);
     const increment = newRows - originRows > 0;
     if (increment) {
-      for (let i = 0; i < newColumns; i++) {
-        const pixels = Array(diff).fill("");
-        newGrid = [...newGrid, ...pixels];
-      }
+      const newPixels = Array(diff * newColumns).fill("");
+      newGrid = [...newGrid, ...newPixels];
     } else {
-      for (let i = 0; i < newColumns; i++) {
-        for (let j = 0; j < diff; j++) {
-          newGrid = newGrid.slice(0, -1);
-        }
-      }
+      newGrid = newGrid.slice(0, newGrid.length - diff * newColumns);
     }
   }
-
-  //console.timeEnd("resizeGrid");
 
   return newGrid;
 };


### PR DESCRIPTION
## Description
`NumberPicker`컴포넌트를 통해 그림판의 픽셀 갯수를 변경 시 속도 향상을 위해 `resizeGrid` 함수의 코드 최적화하였습니다.

- [x] 이중 for문 내부에서 새로운 배열을 생성하거나 `Array.prototype.slice()`를 사용하는 부분은 순회하지 않고 배열을 구할 수 있도록 수정하였습니다.
- [x]  더불어 Pixel 컴포넌트의 `gridBackgroundColor`를 컴포넌트 외부로 분리하였습니다.

### 1.  `width` 조절 시 `resizeGrid` 계산의 속도 차이
<img width="437" alt="스크린샷 2023-06-30 오전 11 01 04" src="https://github.com/LemonScone/pixel-art/assets/11607444/b841bf08-b61d-4542-b9e8-f04b63edc196">

### 2.  `heigth` 조절 시 `resizeGrid` 계산의 속도 차이
<img width="497" alt="스크린샷 2023-06-30 오전 11 00 59" src="https://github.com/LemonScone/pixel-art/assets/11607444/8ed35df8-3138-485f-ab35-7b32746ca5be">

---

**`resizeGrid` 성능은 개선되었다고 판단되지만 렌더링의 속도는 크게 빨라지지 않았습니다.**
### 1.  `width` 조절 시 렌더링 계산의 속도 차이

<img width="1091" alt="스크린샷 2023-06-30 오전 10 57 31" src="https://github.com/LemonScone/pixel-art/assets/11607444/af61c47a-0357-452e-ab5a-239ff3bbd8a9">

### 2.  `heigth` 조절 시 렌더링 계산의 속도 차이

<img width="741" alt="스크린샷 2023-06-30 오전 10 57 45" src="https://github.com/LemonScone/pixel-art/assets/11607444/06da6bee-7aa8-4b51-a0a9-924ef5b62a57">



렌더링 속도 향상의 큰 영향을 끼치지는 못하지만 함수 자체의 코드는 최적화되었으므로 반영하는 것이 좋다고 생각합니다.

## Related Issues

​
resolve #76
​

## Checklist

​
Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
​

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
