### PR TITLE
[Enhancement] Client state 구조 변경

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -88,10 +88,10 @@ export class AuthService {
     });
   }
 
-  async signout(refreshTokenId: number) {
+  async signout(refreshTokenId: string) {
     await this.dbService.execute(
       `DELETE FROM TOKEN
-          WHERE id = ${refreshTokenId}`,
+        WHERE id = ${refreshTokenId}`,
     );
   }
 

--- a/backend/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/backend/src/auth/strategies/jwt-refresh.strategy.ts
@@ -46,7 +46,7 @@ export class JwtRefreshStrategy extends PassportStrategy(
       const { sub, ...rest } = payload;
       return { userId: sub, ...rest, refreshTokenId };
     } catch (error) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException(error);
     }
   }
 }

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -78,6 +78,22 @@ export class ProjectsController {
     );
   }
 
+  @Post('migration')
+  @ApiOperation({
+    summary: '여러 개의 project 생성',
+    description: '신규 project를 여러 개 생성합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '성공적으로 프로젝트를 생성했습니다.',
+  })
+  createProjects(
+    @Req() req,
+    @Body() body: { projects: CreateProjectDto[] },
+  ): Promise<Project> {
+    return this.projectsService.createProjects(req.user.userId, body.projects);
+  }
+
   @Patch(':id')
   @ApiOperation({
     summary: '프로젝트 수정',

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -35,6 +35,15 @@ export class ProjectsController {
     return this.projectsService.getProjectByUserId(req.user.userId);
   }
 
+  @Get('/current')
+  @ApiOperation({
+    summary: 'User의 현재 프로젝트 조회',
+    description: 'User에 설정된 현재 프로젝트를 조회합니다.',
+  })
+  getCurrentProjectByUserId(@Req() req) {
+    return this.projectsService.getCurrentProjectByUserId(req.user.userId);
+  }
+
   @Get(':id')
   @ApiOperation({
     summary: '개별 프로젝트 조회',

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -70,20 +70,22 @@ export class ProjectsService {
                     `;
     const [result] = await this.dbService.execute<Project>(query);
 
-    const query_frame = `SELECT A.id AS projectId
-                              , B.id
-                              , B.grid
-                              , B.animateInterval
-                           FROM PROJECT A
-                           JOIN FRAME B
-                             ON A.id = B.projectId
-                          WHERE A.userId = '${userId}'
-                            AND A.id = ${result.id};`;
+    if (result) {
+      const query_frame = `SELECT A.id AS projectId
+                                , B.id
+                                , B.grid
+                                , B.animateInterval
+                            FROM PROJECT A
+                            JOIN FRAME B
+                              ON A.id = B.projectId
+                            WHERE A.userId = '${userId}'
+                              AND A.id = ${result.id};`;
 
-    const result_frame = await this.dbService.execute<Frame>(query_frame);
+      const result_frame = await this.dbService.execute<Frame>(query_frame);
 
-    result['frames'] = result_frame;
-    result['isPublished'] = Boolean(result.isPublished);
+      result['frames'] = result_frame;
+      result['isPublished'] = Boolean(result.isPublished);
+    }
 
     return result;
   }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -58,9 +58,9 @@ export class UsersService {
   }
 
   async insertUserRefreshToken(userId: number, refreshToken: string) {
-    const hashedRefreshToken = await this.getHashedRefreshToken(refreshToken);
+    // const hashedRefreshToken = await this.getHashedRefreshToken(refreshToken);
     await this.dbService.execute(
-      `INSERT INTO TOKEN (content, userId) VALUES ('${hashedRefreshToken}', '${userId}');`,
+      `INSERT INTO TOKEN (content, userId) VALUES ('${refreshToken}', '${userId}');`,
     );
   }
 
@@ -79,23 +79,24 @@ export class UsersService {
   }
 
   async getRefreshTokenId(userId: string, refreshToken: string) {
-    const tokens = await this.dbService.execute<Token>(
+    const [tokens] = await this.dbService.execute<Token>(
       `SELECT id
             , content
          FROM TOKEN 
-        WHERE userId = '${userId}'`,
+        WHERE userId = '${userId}'
+          AND content = '${refreshToken}`,
     );
 
-    let refreshTokenId = null;
-    for (const token of tokens) {
-      const storedRefreshToken = token.content;
-      if (await bcrypt.compare(refreshToken, storedRefreshToken)) {
-        refreshTokenId = token.id;
-        break;
-      }
-    }
+    // let refreshTokenId = null;
+    // for (const token of tokens) {
+    //   const storedRefreshToken = token.content;
+    //   if (await bcrypt.compare(refreshToken, storedRefreshToken)) {
+    //     refreshTokenId = token.id;
+    //     break;
+    //   }
+    // }
 
-    return refreshTokenId;
+    return tokens.id;
   }
 
   async updateCurrent(userId: string, current: number) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -84,7 +84,7 @@ export class UsersService {
             , content
          FROM TOKEN 
         WHERE userId = '${userId}'
-          AND content = '${refreshToken}`,
+          AND content = '${refreshToken}'`,
     );
 
     // let refreshTokenId = null;

--- a/backend/src/utils/httpExceptionFilter.ts
+++ b/backend/src/utils/httpExceptionFilter.ts
@@ -7,6 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 
+@Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
@@ -14,6 +15,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest();
 
     Logger.error(exception.message);
+
     const status = exception?.getStatus() ?? HttpStatus.INTERNAL_SERVER_ERROR;
     const res: any = exception.getResponse();
 

--- a/frontend/src/components/LoadProject.test.tsx
+++ b/frontend/src/components/LoadProject.test.tsx
@@ -84,7 +84,7 @@ describe("LoadProject", () => {
         localStorage.clear();
       });
 
-      const { project } = projectsStore;
+      const { data: project } = projectsStore;
 
       saveProjectToStorage(project);
 

--- a/frontend/src/components/LoadProject.test.tsx
+++ b/frontend/src/components/LoadProject.test.tsx
@@ -72,7 +72,7 @@ describe("LoadProject", () => {
       const deleteButtons = await screen.findAllByRole("button", {
         name: /delete/i,
       });
-      expect(deleteButtons).toHaveLength(1);
+      expect(deleteButtons).toHaveLength(3);
     });
   });
 
@@ -84,7 +84,7 @@ describe("LoadProject", () => {
         localStorage.clear();
       });
 
-      const project = projectsStore.data[0];
+      const { project } = projectsStore;
 
       saveProjectToStorage(project);
 

--- a/frontend/src/components/LoadProject.tsx
+++ b/frontend/src/components/LoadProject.tsx
@@ -1,29 +1,39 @@
 import { Modal } from "./common/Modal";
 
-import { useAppSelector } from "../hooks/useRedux";
 import { useModal } from "../hooks/useModal";
 
 import ProjectsListItem from "./ProjectsListItem";
+import { useLazyFetchProjectsQuery } from "../store";
+import Skeleton from "./common/Skeleton";
 
 const LoadProject = () => {
-  const { data } = useAppSelector((state) => state.projects);
+  const [getProjects, { data, error, isLoading }] = useLazyFetchProjectsQuery();
   const { open, openModal, closeModal } = useModal();
 
   let content;
 
-  if (data.length) {
-    content = data.map((project) => {
-      return <ProjectsListItem key={project.id} project={project} />;
-    });
-  } else {
-    content = <div>No projects found.</div>;
+  if (isLoading) {
+    content = <Skeleton className="h-48 w-48" times={3} />;
+  } else if (error) {
+    content = <div>Error loading projects</div>;
+  } else if (data) {
+    if (data.length) {
+      content = data.map((project) => {
+        return <ProjectsListItem key={project.id} project={project} />;
+      });
+    } else {
+      content = <div>No projects found.</div>;
+    }
   }
 
   return (
     <>
       <button
         className="grow rounded bg-gray-500 px-4 py-2 text-sm text-gray-100"
-        onClick={openModal}
+        onClick={() => {
+          getProjects();
+          openModal();
+        }}
       >
         LOAD
       </button>

--- a/frontend/src/components/PixelContainer.test.tsx
+++ b/frontend/src/components/PixelContainer.test.tsx
@@ -9,8 +9,9 @@ import { ToolOption } from "../types/Tool";
 
 import { INITIAL_TOOL_OPTIONS } from "../constants";
 import { renderWithProviders } from "../utils/test-utils";
-import projectsStore, { exampleState } from "../tests/fixtures/projectsStore";
 import { Projects } from "../store/slices/projectsSlice";
+
+import projectsStore, { exampleState } from "../tests/fixtures/projectsStore";
 
 describe("PixelContainer", () => {
   beforeEach(() => {
@@ -41,7 +42,7 @@ describe("PixelContainer", () => {
   };
 
   it("should render a grid of pixels", () => {
-    const { project } = projectsStore;
+    const { data: project } = projectsStore;
     const columns = project.gridColumns;
     const rows = project.gridRows;
     renderPixels({});

--- a/frontend/src/components/PixelContainer.test.tsx
+++ b/frontend/src/components/PixelContainer.test.tsx
@@ -41,9 +41,9 @@ describe("PixelContainer", () => {
   };
 
   it("should render a grid of pixels", () => {
-    const columns =
-      projectsStore.data[projectsStore.currentProjectId].gridColumns;
-    const rows = projectsStore.data[projectsStore.currentProjectId].gridRows;
+    const { project } = projectsStore;
+    const columns = project.gridColumns;
+    const rows = project.gridRows;
     renderPixels({});
 
     const pixels = screen.getAllByLabelText("pixel");

--- a/frontend/src/components/PixelContainer.tsx
+++ b/frontend/src/components/PixelContainer.tsx
@@ -11,18 +11,17 @@ import {
   applyEraser,
   applyMove,
   applyPencil,
-  selectProject,
+  selectFrame,
 } from "../store";
 import { useAppDispatch, useAppSelector } from "../hooks/useRedux";
 
 const PixelContainer = () => {
   const dispatch = useAppDispatch();
-  const { currentFrameId, selectedTool, options } = useAppSelector(
+  const { project, selectedTool, options } = useAppSelector(
     (state) => state.projects
   );
-  const project = useAppSelector(selectProject);
+  const frame = useAppSelector(selectFrame);
 
-  const frame = project.frames[currentFrameId];
   const grid = frame.grid;
   const columns = project.gridColumns;
   const rows = project.gridRows;

--- a/frontend/src/components/PixelContainer.tsx
+++ b/frontend/src/components/PixelContainer.tsx
@@ -17,9 +17,11 @@ import { useAppDispatch, useAppSelector } from "../hooks/useRedux";
 
 const PixelContainer = () => {
   const dispatch = useAppDispatch();
-  const { project, selectedTool, options } = useAppSelector(
-    (state) => state.projects
-  );
+  const {
+    data: project,
+    selectedTool,
+    options,
+  } = useAppSelector((state) => state.projects);
   const frame = useAppSelector(selectFrame);
 
   const grid = frame.grid;

--- a/frontend/src/components/ProjectsListItem.test.tsx
+++ b/frontend/src/components/ProjectsListItem.test.tsx
@@ -7,13 +7,8 @@ import { renderWithProviders } from "../utils/test-utils";
 const renderComponent = () => {
   renderWithProviders(
     <MemoryRouter>
-      <ProjectsListItem project={projectsStore.data[0]} />
-    </MemoryRouter>,
-    {
-      preloadedState: {
-        projects: projectsStore,
-      },
-    }
+      <ProjectsListItem project={projectsStore.project} />
+    </MemoryRouter>
   );
 };
 
@@ -27,7 +22,7 @@ describe("ProjectsListItem", () => {
       });
       expect(deleteButton).toBeInTheDocument();
 
-      const title = screen.getByText(projectsStore.data[0].title);
+      const title = screen.getByText(projectsStore.project.title);
       expect(title).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/ProjectsListItem.test.tsx
+++ b/frontend/src/components/ProjectsListItem.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from "../utils/test-utils";
 const renderComponent = () => {
   renderWithProviders(
     <MemoryRouter>
-      <ProjectsListItem project={projectsStore.project} />
+      <ProjectsListItem project={projectsStore.data} />
     </MemoryRouter>
   );
 };
@@ -22,7 +22,7 @@ describe("ProjectsListItem", () => {
       });
       expect(deleteButton).toBeInTheDocument();
 
-      const title = screen.getByText(projectsStore.project.title);
+      const title = screen.getByText(projectsStore.data.title);
       expect(title).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/ProjectsListItem.tsx
+++ b/frontend/src/components/ProjectsListItem.tsx
@@ -7,13 +7,16 @@ import {
 import Animation from "./Animation";
 
 import { useModal } from "../hooks/useModal";
+import { changeProject } from "../store";
 import { useRemoveProjectMutation, useUpdateCurrentMutation } from "../store";
+import { useAppDispatch } from "../hooks/useRedux";
 
 type ProjectsListItemProps = {
   project: Project;
 };
 
 const ProjectsListItem = ({ project }: ProjectsListItemProps) => {
+  const dispatch = useAppDispatch();
   const { closeModal } = useModal();
   const [updateCurrent] = useUpdateCurrentMutation();
   const [removeProject] = useRemoveProjectMutation();
@@ -45,6 +48,7 @@ const ProjectsListItem = ({ project }: ProjectsListItemProps) => {
   }
 
   const handleClick = () => {
+    dispatch(changeProject(project));
     updateCurrent(project.id);
     closeModal();
   };
@@ -88,12 +92,12 @@ const ProjectsListItem = ({ project }: ProjectsListItemProps) => {
           </div>
         </div>
         <button
-          className="text-brand-500 absolute right-3 top-3 flex items-center justify-center rounded-full bg-white p-2 hover:cursor-pointer"
+          className="absolute right-3 top-3 flex items-center justify-center rounded-full bg-white p-2 hover:cursor-pointer"
           title="delete"
           onClick={handleDeleteClick}
         >
-          <div className="flex h-full w-full items-center justify-center rounded-full text-xl hover:bg-gray-50">
-            <TrashIcon width="1em" height="1em" className="text-rose-600" />
+          <div className="flex h-full w-full items-center justify-center rounded-full text-xl hover:bg-gray-200">
+            <TrashIcon width="1em" height="1em" className="text-rose-600 " />
           </div>
         </button>
       </div>

--- a/frontend/src/components/Title.tsx
+++ b/frontend/src/components/Title.tsx
@@ -1,12 +1,12 @@
 import { ChangeEvent, useEffect, useState } from "react";
 import { useInterval } from "../hooks/useInterval";
 import { useAppSelector } from "../hooks/useRedux";
-import { selectProject, useUpdateProjectMutation } from "../store";
+import { useUpdateProjectMutation } from "../store";
 
 import SpinIcon from "./common/icon/SpinIcon";
 
 const Title = () => {
-  const project = useAppSelector(selectProject);
+  const { project } = useAppSelector((state) => state.projects);
 
   const { title: storedTitle } = project;
   const [title, setTitle] = useState("");

--- a/frontend/src/components/Title.tsx
+++ b/frontend/src/components/Title.tsx
@@ -6,7 +6,7 @@ import { useUpdateProjectMutation } from "../store";
 import SpinIcon from "./common/icon/SpinIcon";
 
 const Title = () => {
-  const { project } = useAppSelector((state) => state.projects);
+  const { data: project } = useAppSelector((state) => state.projects);
 
   const { title: storedTitle } = project;
   const [title, setTitle] = useState("");

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,11 +6,11 @@ import { setupStore } from "./store";
 import AppRoutes from "./routes/AppRoutes";
 
 import "./index.css";
-import { initialProjects } from "./tests/fixtures/projectsStore";
+import { initialProject } from "./tests/fixtures/projectsStore";
 import { setupListeners } from "@reduxjs/toolkit/dist/query";
 
 const store = setupStore({
-  projects: initialProjects,
+  projects: initialProject,
 });
 
 setupListeners(store.dispatch);

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -24,11 +24,11 @@ import useAuth from "../hooks/useAuth";
 
 const Editor = () => {
   const dispatch = useAppDispatch();
-  const { project } = useAppSelector((state) => state.projects);
+  const { data: project } = useAppSelector((state) => state.projects);
 
   const { user } = useAuth();
 
-  const { refetch, isLoading } = useFetchProjectQuery();
+  const { refetch, isFetching } = useFetchProjectQuery();
 
   const [pixelSize, setPixelSize] = useState(1);
   const [publish, setPublish] = useState(false);
@@ -37,7 +37,7 @@ const Editor = () => {
     refetch();
   }, [user, refetch]);
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -16,25 +16,19 @@ import ColorPallete from "../components/ColorPallete";
 import PublishToggleSwitch from "../components/PublishToggleSwitch";
 import Loading from "../components/common/Loading";
 
-import {
-  decreseColumn,
-  decreseRow,
-  increseColumn,
-  increseRow,
-  selectProject,
-} from "../store";
+import { decreseColumn, decreseRow, increseColumn, increseRow } from "../store";
 import { useAppDispatch, useAppSelector } from "../hooks/useRedux";
-import { useFetchProjectsQuery } from "../store";
+import { useFetchProjectQuery } from "../store";
 
 import useAuth from "../hooks/useAuth";
 
 const Editor = () => {
   const dispatch = useAppDispatch();
-  const project = useAppSelector(selectProject);
+  const { project } = useAppSelector((state) => state.projects);
 
   const { user } = useAuth();
 
-  const { refetch, isLoading } = useFetchProjectsQuery();
+  const { refetch, isLoading } = useFetchProjectQuery();
 
   const [pixelSize, setPixelSize] = useState(1);
   const [publish, setPublish] = useState(false);

--- a/frontend/src/store/apis/authApi.ts
+++ b/frontend/src/store/apis/authApi.ts
@@ -1,7 +1,12 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import {
+  FetchBaseQueryError,
+  createApi,
+  fetchBaseQuery,
+} from "@reduxjs/toolkit/query/react";
 import { RootState, resetAuth, setAuth } from "..";
 import { Auth, SignInCredentials, SignUpParams, User } from "../../types/Auth";
 import { ONE_MINUTE } from "../../constants";
+import { getDataFromStorage, saveDataToStorage } from "../../utils/storage";
 
 type LoginResponse = Omit<Auth, "user"> & User;
 
@@ -22,12 +27,32 @@ const authApi = createApi({
   endpoints(builder) {
     return {
       login: builder.mutation<LoginResponse, SignInCredentials>({
-        query: (credencials) => {
-          return {
+        async queryFn(arg, _api, _extraOptions, baseQuery) {
+          const result = await baseQuery({
             url: "/auth/signin",
             method: "POST",
-            body: credencials,
-          };
+            body: arg,
+          });
+
+          const data = result.data as LoginResponse;
+
+          const localData = getDataFromStorage();
+          if (data?.accessToken && localData) {
+            await baseQuery({
+              headers: {
+                authorization: `Bearer ${data.accessToken}`,
+              },
+              url: "/projects/migration",
+              method: "POST",
+              body: {
+                projects: localData.stored,
+              },
+            });
+            saveDataToStorage({ stored: [], currentProjectId: "" });
+          }
+          return data
+            ? { data }
+            : { error: result.error as FetchBaseQueryError };
         },
         async onQueryStarted(_, { dispatch, queryFulfilled }) {
           try {

--- a/frontend/src/store/apis/projectsApi.ts
+++ b/frontend/src/store/apis/projectsApi.ts
@@ -20,6 +20,14 @@ const projectsApi = createApi({
   tagTypes: ["Projects", "Project"],
   endpoints(builder) {
     return {
+      fetchProject: builder.query<Project, void>({
+        query: () => {
+          return {
+            url: "/projects/current",
+            method: "GET",
+          };
+        },
+      }),
       fetchProjects: builder.query<Project[], void>({
         providesTags: (result, _error, _projects) =>
           result
@@ -95,6 +103,7 @@ const projectsApi = createApi({
 });
 
 export const {
+  useFetchProjectQuery,
   useFetchProjectsQuery,
   useLazyFetchProjectsQuery,
   useAddProjectMutation,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -18,8 +18,8 @@ import {
   decreseColumn,
   increseRow,
   decreseRow,
-  selectProject,
-  updateCurrent,
+  selectFrame,
+  changeProject,
 } from "./slices/projectsSlice";
 import {
   notificationsReducer,
@@ -71,9 +71,9 @@ export { changeSelectedTool, changePenColor, changePenSize, changeEraserSize };
 export { sendNotification, dismissNotification, toast };
 export { applyPencil, applyEraser, applyBucket, applyMove };
 export { increseColumn, decreseColumn, increseRow, decreseRow };
-export { updateCurrent };
-export { selectProject };
+export { changeProject, selectFrame };
 export {
+  useFetchProjectQuery,
   useFetchProjectsQuery,
   useLazyFetchProjectsQuery,
   useAddProjectMutation,

--- a/frontend/src/store/projectsQuery.ts
+++ b/frontend/src/store/projectsQuery.ts
@@ -4,6 +4,7 @@ import {
   FetchBaseQueryArgs,
 } from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
 import {
+  getCurrentProjectFromStorage,
   getDataFromStorage,
   removeProjectFromStorage,
   saveProjectToStorage,
@@ -15,7 +16,7 @@ import httpMethod from "../constants/httpMethod";
 import { pause } from "../utils/pause";
 import { randomStr } from "../utils/random";
 
-import { RootState, updateCurrent } from ".";
+import { RootState } from ".";
 
 const projectsQuery = ({ baseUrl, prepareHeaders }: FetchBaseQueryArgs) => {
   const baseQuery = fetchBaseQuery({ baseUrl, prepareHeaders });
@@ -35,13 +36,17 @@ const getDataFromLocalStorage = async (
 ) => {
   switch (method) {
     case httpMethod.GET: {
-      const localStorageData = getDataFromStorage();
-      await pause();
-      if (localStorageData.stored.length) {
-        api.dispatch(updateCurrent(localStorageData.currentProjectId));
-        return { data: localStorageData.stored };
+      if (api.endpoint === "fetchProjects") {
+        const localStorageData = getDataFromStorage();
+        await pause();
+        if (localStorageData.stored.length) {
+          return { data: localStorageData.stored };
+        }
+        return { data: [] };
+      } else {
+        const currentProject = getCurrentProjectFromStorage();
+        return { data: currentProject };
       }
-      return { data: [] };
     }
     case httpMethod.POST: {
       const { id, ...rest } = body;

--- a/frontend/src/store/slices/projectsSlice.ts
+++ b/frontend/src/store/slices/projectsSlice.ts
@@ -8,36 +8,17 @@ import {
   isGridsEqual,
   resizeGrid,
 } from "../../utils/grid";
-import { initialProjects } from "../../tests/fixtures/projectsStore";
+import { initialProject } from "../../tests/fixtures/projectsStore";
 
 import { setAuth } from "./authSlice";
 import { projectsApi } from "../apis/projectsApi";
-import { usersApi } from "../apis/usersApi";
 import { RootState } from "..";
 
-type Frame = {
-  id: number;
-  projectId: number | string;
-  grid: string[];
-  animateInterval: number;
-};
-
-type Project = {
-  id: number | string;
-  animate: boolean;
-  cellSize: number;
-  gridColumns: number;
-  gridRows: number;
-  pallete: string[];
-  title: string;
-  description: string;
-  isPublished: boolean;
-
-  frames: Frame[];
-};
+import type { Project } from "../../types/Project";
 
 export type Projects = {
   data: Project[];
+  project: Project;
   currentFrameId: number;
   currentProjectId: number | string;
   selectedTool: keyof ToolOption;
@@ -52,6 +33,7 @@ type MoveOptions = {
 
 const initialState: Projects = {
   data: [],
+  project: initialProject,
   currentFrameId: 0,
   currentProjectId: 0,
   selectedTool: "pen",
@@ -65,17 +47,14 @@ const projectsSlice = createSlice({
     applyPencil(state, action: PayloadAction<number>) {
       const color = state.options.pen.color;
       const size = state.options.pen.size;
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
       const newGrid = currentFrame?.grid.slice();
-      const columns = currentProject?.gridColumns;
-      const rows = currentProject?.gridRows;
+      const columns = project.gridColumns;
+      const rows = project.gridRows;
 
       if (columns && rows) {
         const targetIndexes = getTargetIndexes(
@@ -98,18 +77,15 @@ const projectsSlice = createSlice({
     },
     applyEraser(state, action: PayloadAction<number>) {
       const size = state.options.eraser.size;
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
       const newGrid = currentFrame?.grid.slice();
-      const columns = currentProject?.gridColumns;
-      const rows = currentProject?.gridRows;
+      const columns = project.gridColumns;
+      const rows = project.gridRows;
 
       if (columns && rows) {
         const targetIndexes = getTargetIndexes(
@@ -134,18 +110,15 @@ const projectsSlice = createSlice({
     },
     applyBucket(state, action: PayloadAction<number>) {
       const penColor = state.options.pen.color;
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
       const newGrid = currentFrame?.grid.slice();
-      const columns = currentProject?.gridColumns;
-      const rows = currentProject?.gridRows;
+      const columns = project.gridColumns;
+      const rows = project.gridRows;
 
       if (currentFrame && newGrid && columns && rows) {
         const originColor = currentFrame.grid[action.payload];
@@ -167,17 +140,14 @@ const projectsSlice = createSlice({
       }
     },
     applyMove(state, action: PayloadAction<MoveOptions>) {
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
-      const columns = currentProject?.gridColumns;
-      const rows = currentProject?.gridRows;
+      const columns = project.gridColumns;
+      const rows = project.gridRows;
 
       if (columns && rows && currentFrame) {
         let newGrid = currentFrame.grid;
@@ -249,18 +219,15 @@ const projectsSlice = createSlice({
       state.options.eraser.size = action.payload;
     },
     increseColumn(state) {
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
-      if (currentProject && currentFrame) {
-        const columns = currentProject.gridColumns;
-        const rows = currentProject.gridRows;
+      if (currentFrame) {
+        const columns = project.gridColumns;
+        const rows = project.gridRows;
 
         currentFrame.grid = resizeGrid(
           currentFrame?.grid,
@@ -269,22 +236,19 @@ const projectsSlice = createSlice({
           rows,
           columns + 1
         );
-        currentProject.gridColumns += 1;
+        project.gridColumns += 1;
       }
     },
     decreseColumn(state) {
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
-      if (currentProject && currentFrame) {
-        const columns = currentProject.gridColumns;
-        const rows = currentProject.gridRows;
+      if (currentFrame) {
+        const columns = project.gridColumns;
+        const rows = project.gridRows;
 
         currentFrame.grid = resizeGrid(
           currentFrame?.grid,
@@ -293,22 +257,19 @@ const projectsSlice = createSlice({
           rows,
           columns - 1
         );
-        currentProject.gridColumns -= 1;
+        project.gridColumns -= 1;
       }
     },
     increseRow(state) {
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
-      if (currentProject && currentFrame) {
-        const columns = currentProject.gridColumns;
-        const rows = currentProject.gridRows;
+      if (currentFrame) {
+        const columns = project.gridColumns;
+        const rows = project.gridRows;
 
         currentFrame.grid = resizeGrid(
           currentFrame?.grid,
@@ -317,22 +278,19 @@ const projectsSlice = createSlice({
           rows + 1,
           columns
         );
-        currentProject.gridRows += 1;
+        project.gridRows += 1;
       }
     },
     decreseRow(state) {
-      const { data, currentProjectId, currentFrameId } = state;
+      const { project, currentFrameId } = state;
 
-      const currentProject = data.find(
-        (project) => project.id === currentProjectId
-      );
-      const currentFrame = currentProject?.frames.find(
+      const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
       );
 
-      if (currentProject && currentFrame) {
-        const columns = currentProject.gridColumns;
-        const rows = currentProject.gridRows;
+      if (currentFrame) {
+        const columns = project.gridColumns;
+        const rows = project.gridRows;
 
         currentFrame.grid = resizeGrid(
           currentFrame?.grid,
@@ -341,17 +299,28 @@ const projectsSlice = createSlice({
           rows - 1,
           columns
         );
-        currentProject.gridRows -= 1;
+        project.gridRows -= 1;
       }
     },
-    updateCurrent(state, action: PayloadAction<string | number>) {
-      state.currentProjectId = action.payload;
+    changeProject(state, action: PayloadAction<Project>) {
+      state.project = action.payload;
+      state.currentProjectId = action.payload.id;
+      state.currentFrameId = action.payload.frames[0].id;
     },
   },
   extraReducers(builder) {
     builder.addCase(setAuth, (state, { payload }) => {
       state.currentProjectId = payload.user.current;
     });
+    builder.addMatcher(
+      projectsApi.endpoints.fetchProject.matchFulfilled,
+      (state, { payload }) => {
+        const project = payload ?? initialProject;
+        console.log({ project });
+        state.project = project;
+        state.currentFrameId = project.frames[0].id;
+      }
+    );
     builder.addMatcher(
       projectsApi.endpoints.fetchProjects.matchFulfilled,
       (state, { payload }) => {
@@ -363,27 +332,16 @@ const projectsSlice = createSlice({
     builder.addMatcher(
       projectsApi.endpoints.updateProject.matchFulfilled,
       (state, { payload }) => {
-        const idx = state.data.findIndex(
-          ({ id }) => id === state.currentProjectId
-        );
-        if (idx !== -1) {
-          state.data[idx] = payload;
-        }
-      }
-    );
-    builder.addMatcher(
-      usersApi.endpoints.updateCurrent.matchFulfilled,
-      (state, { payload }) => {
-        state.currentProjectId = payload;
+        state.project = payload;
       }
     );
   },
 });
 
-export const selectProject = (state: RootState) => {
-  const { data, currentProjectId } = state.projects;
-  const project = data.find(({ id }) => id === currentProjectId);
-  return project || initialProjects.data[0];
+export const selectFrame = (state: RootState) => {
+  const { project, currentFrameId } = state.projects;
+  const frame = project.frames.find(({ id }) => id === currentFrameId);
+  return frame || initialProject.frames[0];
 };
 
 export const {
@@ -399,7 +357,7 @@ export const {
   decreseColumn,
   increseRow,
   decreseRow,
-  updateCurrent,
+  changeProject,
 } = projectsSlice.actions;
 
 export const projectsReducer = projectsSlice.reducer;

--- a/frontend/src/store/slices/projectsSlice.ts
+++ b/frontend/src/store/slices/projectsSlice.ts
@@ -17,7 +17,7 @@ import { RootState } from "..";
 import type { Project } from "../../types/Project";
 
 export type Projects = {
-  project: Project;
+  data: Project;
   currentFrameId: number;
   currentProjectId: number | string;
   selectedTool: keyof ToolOption;
@@ -31,7 +31,7 @@ type MoveOptions = {
 };
 
 const initialState: Projects = {
-  project: initialProject.project,
+  data: initialProject.data,
   currentFrameId: 0,
   currentProjectId: 0,
   selectedTool: "pen",
@@ -45,7 +45,7 @@ const projectsSlice = createSlice({
     applyPencil(state, action: PayloadAction<number>) {
       const color = state.options.pen.color;
       const size = state.options.pen.size;
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -75,7 +75,7 @@ const projectsSlice = createSlice({
     },
     applyEraser(state, action: PayloadAction<number>) {
       const size = state.options.eraser.size;
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -108,7 +108,7 @@ const projectsSlice = createSlice({
     },
     applyBucket(state, action: PayloadAction<number>) {
       const penColor = state.options.pen.color;
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -138,7 +138,7 @@ const projectsSlice = createSlice({
       }
     },
     applyMove(state, action: PayloadAction<MoveOptions>) {
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -217,7 +217,7 @@ const projectsSlice = createSlice({
       state.options.eraser.size = action.payload;
     },
     increseColumn(state) {
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -238,7 +238,7 @@ const projectsSlice = createSlice({
       }
     },
     decreseColumn(state) {
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -259,7 +259,7 @@ const projectsSlice = createSlice({
       }
     },
     increseRow(state) {
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -280,7 +280,7 @@ const projectsSlice = createSlice({
       }
     },
     decreseRow(state) {
-      const { project, currentFrameId } = state;
+      const { data: project, currentFrameId } = state;
 
       const currentFrame = project.frames.find(
         (frame) => frame.id === currentFrameId
@@ -301,7 +301,7 @@ const projectsSlice = createSlice({
       }
     },
     changeProject(state, action: PayloadAction<Project>) {
-      state.project = action.payload;
+      state.data = action.payload;
       state.currentProjectId = action.payload.id;
       state.currentFrameId = action.payload.frames[0].id;
     },
@@ -314,24 +314,23 @@ const projectsSlice = createSlice({
       projectsApi.endpoints.fetchProject.matchFulfilled,
       (state, { payload }) => {
         const project = payload ?? initialProject;
-        console.log({ project });
-        state.project = project;
+        state.data = project;
         state.currentFrameId = project.frames[0].id;
       }
     );
     builder.addMatcher(
       projectsApi.endpoints.updateProject.matchFulfilled,
       (state, { payload }) => {
-        state.project = payload;
+        state.data = payload;
       }
     );
   },
 });
 
 export const selectFrame = (state: RootState) => {
-  const { project, currentFrameId } = state.projects;
+  const { data: project, currentFrameId } = state.projects;
   const frame = project.frames.find(({ id }) => id === currentFrameId);
-  return frame || initialProject.project.frames[0];
+  return frame || initialProject.data.frames[0];
 };
 
 export const {

--- a/frontend/src/store/slices/projectsSlice.ts
+++ b/frontend/src/store/slices/projectsSlice.ts
@@ -313,7 +313,7 @@ const projectsSlice = createSlice({
     builder.addMatcher(
       projectsApi.endpoints.fetchProject.matchFulfilled,
       (state, { payload }) => {
-        const project = payload ?? initialProject;
+        const project = payload ?? initialProject.data;
         state.data = project;
         state.currentFrameId = project.frames[0].id;
       }

--- a/frontend/src/store/slices/projectsSlice.ts
+++ b/frontend/src/store/slices/projectsSlice.ts
@@ -17,7 +17,6 @@ import { RootState } from "..";
 import type { Project } from "../../types/Project";
 
 export type Projects = {
-  data: Project[];
   project: Project;
   currentFrameId: number;
   currentProjectId: number | string;
@@ -32,8 +31,7 @@ type MoveOptions = {
 };
 
 const initialState: Projects = {
-  data: [],
-  project: initialProject,
+  project: initialProject.project,
   currentFrameId: 0,
   currentProjectId: 0,
   selectedTool: "pen",
@@ -322,14 +320,6 @@ const projectsSlice = createSlice({
       }
     );
     builder.addMatcher(
-      projectsApi.endpoints.fetchProjects.matchFulfilled,
-      (state, { payload }) => {
-        if (payload.length) {
-          state.data = payload;
-        }
-      }
-    );
-    builder.addMatcher(
       projectsApi.endpoints.updateProject.matchFulfilled,
       (state, { payload }) => {
         state.project = payload;
@@ -341,7 +331,7 @@ const projectsSlice = createSlice({
 export const selectFrame = (state: RootState) => {
   const { project, currentFrameId } = state.projects;
   const frame = project.frames.find(({ id }) => id === currentFrameId);
-  return frame || initialProject.frames[0];
+  return frame || initialProject.project.frames[0];
 };
 
 export const {

--- a/frontend/src/tests/fixtures/projectsStore.ts
+++ b/frontend/src/tests/fixtures/projectsStore.ts
@@ -9,42 +9,7 @@ const frame = {
   animateInterval: 25,
 };
 
-const initialProject = {
-  id: "initial",
-  animate: false,
-  cellSize: 10,
-  gridColumns: 16,
-  gridRows: 16,
-  pallete: INITIAL_COLOR_PALLETE,
-  title: "",
-  description: "",
-  isPublished: false,
-  frames: [
-    {
-      id: 0,
-      projectId: "initial",
-      grid: Array.from({ length: 16 * 16 }, () => ""),
-      animateInterval: 25,
-    },
-  ],
-};
-
 const projectsStore = {
-  data: [
-    {
-      id: 0,
-      animate: false,
-      cellSize: 10,
-      gridColumns: 20,
-      gridRows: 20,
-      pallete: INITIAL_COLOR_PALLETE,
-      title: "title",
-      description: "description",
-      isPublished: false,
-
-      frames: [frame],
-    },
-  ],
   project: {
     id: 0,
     animate: false,
@@ -70,28 +35,6 @@ const exampleState = (
   gridRows: number
 ) => {
   return {
-    data: [
-      {
-        id: 0,
-        animate: false,
-        cellSize: 10,
-        gridColumns,
-        gridRows,
-        pallete: INITIAL_COLOR_PALLETE,
-        title: "title",
-        description: "description",
-        isPublished: false,
-
-        frames: [
-          {
-            id: 0,
-            projectId: 0,
-            grid,
-            animateInterval: 25,
-          },
-        ],
-      },
-    ],
     project: {
       id: 0,
       animate: false,
@@ -119,14 +62,31 @@ const exampleState = (
   };
 };
 
-const initialProjects = {
-  data: [],
-  project: initialProject,
+const initialProject = {
+  project: {
+    id: "initial",
+    animate: false,
+    cellSize: 10,
+    gridColumns: 16,
+    gridRows: 16,
+    pallete: INITIAL_COLOR_PALLETE,
+    title: "",
+    description: "",
+    isPublished: false,
+    frames: [
+      {
+        id: 0,
+        projectId: "initial",
+        grid: Array.from({ length: 16 * 16 }, () => ""),
+        animateInterval: 25,
+      },
+    ],
+  },
   currentProjectId: "initial",
   currentFrameId: 0,
   selectedTool: "pen" as keyof ToolOption,
   options: INITIAL_TOOL_OPTIONS,
 };
 
-export { exampleState, initialProjects, initialProject };
+export { exampleState, initialProject };
 export default projectsStore;

--- a/frontend/src/tests/fixtures/projectsStore.ts
+++ b/frontend/src/tests/fixtures/projectsStore.ts
@@ -10,7 +10,7 @@ const frame = {
 };
 
 const projectsStore = {
-  project: {
+  data: {
     id: 0,
     animate: false,
     cellSize: 10,
@@ -35,7 +35,7 @@ const exampleState = (
   gridRows: number
 ) => {
   return {
-    project: {
+    data: {
       id: 0,
       animate: false,
       cellSize: 10,
@@ -63,7 +63,7 @@ const exampleState = (
 };
 
 const initialProject = {
-  project: {
+  data: {
     id: "initial",
     animate: false,
     cellSize: 10,

--- a/frontend/src/tests/fixtures/projectsStore.ts
+++ b/frontend/src/tests/fixtures/projectsStore.ts
@@ -9,6 +9,26 @@ const frame = {
   animateInterval: 25,
 };
 
+const initialProject = {
+  id: "initial",
+  animate: false,
+  cellSize: 10,
+  gridColumns: 16,
+  gridRows: 16,
+  pallete: INITIAL_COLOR_PALLETE,
+  title: "",
+  description: "",
+  isPublished: false,
+  frames: [
+    {
+      id: 0,
+      projectId: "initial",
+      grid: Array.from({ length: 16 * 16 }, () => ""),
+      animateInterval: 25,
+    },
+  ],
+};
+
 const projectsStore = {
   data: [
     {
@@ -25,6 +45,19 @@ const projectsStore = {
       frames: [frame],
     },
   ],
+  project: {
+    id: 0,
+    animate: false,
+    cellSize: 10,
+    gridColumns: 20,
+    gridRows: 20,
+    pallete: INITIAL_COLOR_PALLETE,
+    title: "title",
+    description: "description",
+    isPublished: false,
+
+    frames: [frame],
+  },
   currentProjectId: 0,
   currentFrameId: 0,
   selectedTool: "pen" as keyof ToolOption,
@@ -59,6 +92,26 @@ const exampleState = (
         ],
       },
     ],
+    project: {
+      id: 0,
+      animate: false,
+      cellSize: 10,
+      gridColumns,
+      gridRows,
+      pallete: INITIAL_COLOR_PALLETE,
+      title: "title",
+      description: "description",
+      isPublished: false,
+
+      frames: [
+        {
+          id: 0,
+          projectId: 0,
+          grid,
+          animateInterval: 25,
+        },
+      ],
+    },
     currentProjectId: 0,
     currentFrameId: 0,
     selectedTool: "pen" as keyof ToolOption,
@@ -67,32 +120,13 @@ const exampleState = (
 };
 
 const initialProjects = {
-  data: [
-    {
-      id: "initial",
-      animate: false,
-      cellSize: 10,
-      gridColumns: 16,
-      gridRows: 16,
-      pallete: INITIAL_COLOR_PALLETE,
-      title: "",
-      description: "",
-      isPublished: false,
-      frames: [
-        {
-          id: 0,
-          projectId: "initial",
-          grid: Array.from({ length: 16 * 16 }, () => ""),
-          animateInterval: 25,
-        },
-      ],
-    },
-  ],
+  data: [],
+  project: initialProject,
   currentProjectId: "initial",
   currentFrameId: 0,
   selectedTool: "pen" as keyof ToolOption,
   options: INITIAL_TOOL_OPTIONS,
 };
 
-export { exampleState, initialProjects };
+export { exampleState, initialProjects, initialProject };
 export default projectsStore;

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -118,6 +118,7 @@ const removeProjectFromStorage = (removeId: string) => {
 };
 
 export {
+  saveDataToStorage,
   getDataFromStorage,
   saveProjectToStorage,
   updateProjectFromStorage,

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -15,6 +15,7 @@ const updateCurrentProjectIdFromStorage = (currentProjectId: number) => {
     const dataStored = getDataFromStorage();
     if (dataStored) {
       dataStored.currentProjectId = currentProjectId;
+      saveDataToStorage(dataStored);
     }
   } catch (e) {
     return false;

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -10,6 +10,25 @@ const getDataFromStorage = () => {
   }
 };
 
+const getCurrentProjectFromStorage = () => {
+  try {
+    const data = getDataFromStorage();
+    if (data) {
+      const { stored, currentProjectId } = data;
+      if (stored.length) {
+        const find = (stored as Project[]).find(
+          ({ id }) => id === currentProjectId
+        );
+        return find;
+      } else {
+        return null;
+      }
+    }
+  } catch (e) {
+    return null;
+  }
+};
+
 const updateCurrentProjectIdFromStorage = (currentProjectId: number) => {
   try {
     const dataStored = getDataFromStorage();
@@ -41,12 +60,12 @@ const updateProjectFromStorage = (data: Project) => {
     return false;
   }
 };
-const saveProjectToStorage = <T extends { id?: string }>(data: T) => {
+const saveProjectToStorage = <T extends { id?: Project["id"] }>(data: T) => {
   try {
     let dataStored = getDataFromStorage();
     if (dataStored) {
       dataStored.stored.push(data);
-      dataStored.currentProjectId = dataStored.data.id;
+      dataStored.currentProjectId = data.id;
     } else {
       dataStored = {
         stored: [data],
@@ -73,22 +92,25 @@ const saveDataToStorage = <T>(data: T) => {
 const removeProjectFromStorage = (removeId: string) => {
   const dataStored = getDataFromStorage();
   if (dataStored) {
-    let newCurrent = "";
     const stored = dataStored.stored as Project[];
     const idx = stored.findIndex(({ id }) => id.toString() === removeId);
     const rest = stored.filter(({ id }) => id.toString() !== removeId);
 
     const newDataStored = {
       stored: rest,
-      current: "",
+      currentProjectId: "",
     };
 
+    let newCurrent = "";
     if (newDataStored.stored.length === 0) {
       newCurrent = "";
-    } else {
+    } else if (idx > 0) {
       newCurrent = stored[idx - 1].id.toString();
+    } else {
+      newCurrent = newDataStored.stored[0].id.toString();
     }
-    newDataStored.current = newCurrent;
+
+    newDataStored.currentProjectId = newCurrent.toString();
 
     return saveDataToStorage(newDataStored);
   }
@@ -101,4 +123,5 @@ export {
   updateProjectFromStorage,
   updateCurrentProjectIdFromStorage,
   removeProjectFromStorage,
+  getCurrentProjectFromStorage,
 };


### PR DESCRIPTION
## Description

​- projects store의 projects.project를 projects.data로 수정했습니다.
- `GET /projects/currnet`를 추가, 현재 사용자의 현재 프로젝트를 불러옵니다.
- `POST /projects/migration`을 추가, 로그인 후 localStorage에 저장된 데이터 migration
- refreshToken을 DB에서 평문으로 저장하도록 수정
  - hash 값을  저장했었는데 비교하는 부분에서 시간이 3초나 지연되는 문제로 인해 주석 처리 [참고](https://github.com/LemonScone/pixel-art/wiki/%F0%9F%94%90-%EC%9D%B8%EC%A6%9D#hash-%EA%B0%92%EC%9C%BC%EB%A1%9C-%EC%A0%80%EC%9E%A5%ED%95%98%EA%B8%B0)

## Related Issues

resolve #100
​

## Checklist
​
Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
​

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
