### PR TITLE
[Feature] 비밀번호 찾기 api 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "cookie-parser": "^1.4.6",
         "helmet": "^7.0.0",
         "mysql2": "^3.3.2",
+        "nodemailer": "^6.9.4",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",
@@ -5878,6 +5879,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
       "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.4.tgz",
+      "integrity": "sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "cookie-parser": "^1.4.6",
     "helmet": "^7.0.0",
     "mysql2": "^3.3.2",
+    "nodemailer": "^6.9.4",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -39,6 +39,7 @@ import {
   CreateUserSuccessResponseDto,
 } from './dto/create-user-response.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { VerifyResetPasswordDto } from './dto/verify-reset-password.dto';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -174,7 +175,7 @@ export class AuthController {
     description: '비밀번호를 변경을 위한 token의 유효성을 검증합니다.',
   })
   @Post('verify-password-token')
-  async verifyPasswordToken(@Body() { token }: { token: string }) {
+  async verifyPasswordToken(@Body() { token }: VerifyResetPasswordDto) {
     return await this.authService.verifyPasswordToken(token);
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpStatus,
+  Param,
   Post,
   Req,
   Res,
@@ -37,6 +38,7 @@ import {
   CreateUserFailedResponseDto,
   CreateUserSuccessResponseDto,
 } from './dto/create-user-response.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -165,5 +167,32 @@ export class AuthController {
       this.configService.get<string>('JWT_EXPIRATION_TIME'),
     );
     return { ...response, expired, id: userId };
+  }
+
+  @ApiOperation({
+    summary: '비밀번호 변경 token 유효성 검증',
+    description: '비밀번호를 변경을 위한 token의 유효성을 검증합니다.',
+  })
+  @Post('verify-password-token')
+  async verifyPasswordToken(@Body() { token }: { token: string }) {
+    return await this.authService.verifyPasswordToken(token);
+  }
+
+  @ApiOperation({
+    summary: '비밀번호 찾기',
+    description: '비밀번호 초기화 메일을 발송합니다.',
+  })
+  @Post('forgot-password/:email')
+  async sendEmailForgotPassword(@Param('email') email: string) {
+    await this.authService.sendResetPasswordMail(email);
+  }
+
+  @ApiOperation({
+    summary: '비밀번호 변경',
+    description: '비밀번호를 변경합니다.',
+  })
+  @Post('reset-password')
+  async resetPassword(@Body() { token, password }: ResetPasswordDto) {
+    await this.authService.resetPassword(token, password);
   }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -189,8 +189,8 @@ describe('AuthService', () => {
     });
 
     const token = await service.sendResetPasswordMail(user.email);
-    const valid = await service.verifyPasswordToken(token);
-    expect(valid).toBeTruthy();
+    const verifiedToken = await service.verifyPasswordToken(token);
+    expect(verifiedToken).toBeDefined();
   });
 
   it('throws if verifyPasswordToken is called with an invalid token', async () => {

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @ApiProperty({
+    example: 'token',
+    description: 'token',
+    required: true,
+  })
+  @IsString()
+  token: string;
+
+  @ApiProperty({
+    example: '12345',
+    description: 'user password',
+    required: true,
+  })
+  @IsString()
+  @MinLength(4)
+  @MaxLength(20)
+  @Matches(/^[a-zA-Z0-9]*$/)
+  password: string;
+}

--- a/backend/src/auth/dto/verify-reset-password.dto.ts
+++ b/backend/src/auth/dto/verify-reset-password.dto.ts
@@ -1,0 +1,6 @@
+import { PickType } from '@nestjs/swagger';
+import { ResetPasswordDto } from './reset-password.dto';
+
+export class VerifyResetPasswordDto extends PickType(ResetPasswordDto, [
+  'token',
+] as const) {}

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -3,6 +3,7 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { DbService } from '../db/db.service';
 import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -10,7 +11,7 @@ describe('UsersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
-      providers: [UsersService, ConfigService, DbService],
+      providers: [UsersService, ConfigService, DbService, JwtService],
     }).compile();
 
     controller = module.get<UsersController>(UsersController);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -19,7 +19,7 @@ import {
   UserRegisterFailedResponseDto,
   UserRegisterSuccessResponseDto,
 } from './dto/users-register-response.dto';
-import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt.guard';
 import { UpdateUserCurrentDto } from './dto/update-user-current.dto';
 
 @Controller('users')

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -108,4 +108,45 @@ export class UsersService {
 
     return current;
   }
+
+  async createPasswordToken(userId: number, token: string) {
+    await this.dbService.execute(
+      `INSERT INTO RESET_PASSWORD_TOKEN (userId, token) VALUES ('${userId}', '${token}');`,
+    );
+
+    const [lastInsert] = await this.dbService.execute(
+      'SELECT LAST_INSERT_ID() as id',
+    );
+
+    return {
+      id: lastInsert['id'],
+      userId,
+      token,
+    };
+  }
+
+  async removePasswordToken(userId: number) {
+    await this.dbService.execute(
+      `DELETE FROM RESET_PASSWORD_TOKEN
+        WHERE userId = ${userId}`,
+    );
+  }
+
+  async findPasswordToken(
+    userId: number,
+  ): Promise<{ id: number; token: string }> {
+    const [result] = await this.dbService.execute<any>(
+      `SELECT id, token FROM RESET_PASSWORD_TOKEN WHERE userId = '${userId}'`,
+    );
+
+    return result;
+  }
+
+  async updatePassword(userId: string, password: string) {
+    await this.dbService.execute(
+      `UPDATE USER SET 
+              password = '${password}'
+        WHERE id = ${userId}`,
+    );
+  }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -148,5 +148,7 @@ export class UsersService {
               password = '${password}'
         WHERE id = ${userId}`,
     );
+
+    await this.dbService.execute(`DELETE FROM TOKEN WHERE userId = ${userId}`);
   }
 }

--- a/backend/src/utils/mail.ts
+++ b/backend/src/utils/mail.ts
@@ -1,0 +1,19 @@
+const renderMailContent = (name, url) => {
+  return `<!DOCTYPE html>
+		<html>
+		<head>
+				<title>Forget Password Email</title>
+		</head>
+		<body>
+				<div>
+						<h3>Dear ${name},</h3>
+						<p>You requested for a password reset, kindly use this <a href=${url}>link</a> to reset your password.</p>
+            <p>If you don’t use this link within 3 hours, it will expire.</p>
+						<br>
+						<p>Cheers!</p>
+				</div>
+		</body>
+		</html>`;
+};
+
+export { renderMailContent };

--- a/backend/test/ConfigServiceMock.ts
+++ b/backend/test/ConfigServiceMock.ts
@@ -13,6 +13,17 @@ const ConfigServiceMock = {
           return 'refresh_secret';
         case 'JWT_REFRESH_EXPIRATION_TIME':
           return '36000';
+        case 'JWT_RESET_PASSWORD_SECRET':
+          return 'secret';
+        case 'JWT_RESET_PASSWORD_EXPIRATION_TIME':
+          return '10800000';
+        case 'EMAIL_ADDRESS':
+          return 'no-reply@gridapixel.com';
+        case 'EMAIL_PASSWORD':
+          return '1234';
+        case 'CLIENT_URL':
+          return 'http://localhost:3000';
+
         default:
           return null;
       }

--- a/backend/test/test.helper.ts
+++ b/backend/test/test.helper.ts
@@ -11,7 +11,13 @@ export async function clearDB() {
   });
 
   try {
-    const tables = ['FRAME', 'PROJECT', 'TOKEN', 'USER'];
+    const tables = [
+      'FRAME',
+      'PROJECT',
+      'RESET_PASSWORD_TOKEN',
+      'TOKEN',
+      'USER',
+    ];
     await pool.execute(`SET FOREIGN_KEY_CHECKS=0;`);
     for (const table of tables) {
       await pool.execute(`TRUNCATE TABLE ${table};`);


### PR DESCRIPTION
## Description

- 비밀번호를 새로 설정하기 위한 링크를 포함한 메일을 전송하기 위해 nodemailer를 설치했습니다. 0912dc8
- 비밀번호 찾기 요청의 유효성을 확인하기 위한 `token`을 생성합니다. 
  - `token`을 저장하기 위한 Table을 추가했습니다.
  - CRUD 메서드를 추가했습니다.
- 추가된 endpoint
 -  `POST /auth/forgot-password/:email`
   - 유효한 email인지 확인합니다. 
   - DB에 저장된 기존 `token`을 삭제합니다.
   - 새 `token`을 생성합니다. user email, id, 현재시간 hash값이 포함됩니다.
   - DB에 user id, 생성된 token의 현재시간 hash값을 저장합니다. 
   - 비밀번호를 새로 설정하기 위한 링크를 포함한 메일을 전송합니다. (링크 주소에 `token`이 포함됩니다)
 - `POST /auth/reset-password` 
   - `token`의 유효성을 검증합니다.
     - token의 만료시간, token에 담긴 정보를 DB의 정보와 비교합니다.   
   - 유효한 요청인 경우 비밀번호를 변경합니다.
   - 인증 과정에 `refresh token`을 사용하고 있습니다. 비밀번호를 변경했다면 기존 비밀번호로 로그인된 인증은 보안상 무효가 되어야 한다고 판단하여 DB에 저장된 `refresh token`을 삭제합니다. 
 - `GET /auth/verify-password-token`
   - `token`의 유효성을 검증합니다.
   - 새 비밀번호 변경 링크에 접속했을 때  유효한 `token`인지 확인하기 위한 용도입니다. 


## Related Issues

​
resolve #132
​

## Checklist

​
Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
​

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
